### PR TITLE
nomad-filebeat: fix log treatment in filebeat tmpl for api router

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-from frolvlad/alpine-glibc:alpine-3.4
+FROM frolvlad/alpine-glibc:alpine-3.4
 
 # install dumb-init, a simple process supervisor and init system
 ENV DUMB_INIT_VERSION 1.1.3

--- a/filebeat.yml.tmpl
+++ b/filebeat.yml.tmpl
@@ -6,10 +6,14 @@ filebeat:
   registry_file: /local/.filebeat
   prospectors:
     - input_type: log
+    {{ if ne (var "APPTYPE") "nginx" }}
       json:
         key_under_root: true
         overwrite_keys: true
         add_error_key: true
+    {{ else }}
+      document_type: nginx_access
+    {{ end }}
       paths:
         - /alloc/logs/*.stdout.*
       exclude_files:
@@ -24,10 +28,14 @@ filebeat:
           {{ if $meta_vars }}meta:{{ range $meta_vars | split "," }}
             {{ if var . }}{{ . | replace "NOMAD_META_" "" | lower }}: {{ var . }}{{ end }}{{ end }}{{ end }}{{ end }}
 {{ if eq (var "EXCLUDE_STDERR") "" }}    - input_type: log
+    {{ if ne (var "APPTYPE") "nginx" }}
       json:
         key_under_root: true
         overwrite_keys: true
         add_error_key: true
+    {{ else }}
+      document_type: nginx_error
+    {{ end }}
       paths:
         - /alloc/logs/*.stderr.*
       exclude_files:


### PR DESCRIPTION
## O que este PR faz?
docker-nomad-filebeat: add fix log treatment in filebeat template for api-router
    
    api-router dont generate json logs, so, nomad-beat dont get this logs
    because settings in filebeat template is only applied to get json.
    The commit add a conditional when var APPTYPE is nginx, removing
    settings json and add settings nginx.

## Documentação de Impacto
None

### Quais módulos ou funcionalidades poderão ser afetados por esta alteração?
nomad-beat 

### Quais podem ser os impactos ou comportamento dos serviços em caso de falha?
Dont get logs

## Testes de funcionalidade e análise estática
None

## Envolve migration ou outros projetos em paralelo?
None

## O rollback deste PR envolve algum passo adicional além de um Revert?
None
